### PR TITLE
apply <Layout /> component through gatsby-ssr.js and gatsby-browser.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,9 +316,15 @@ I have published this website under the [MIT License](#license).
   * CSS Tricks - Grid
   * Layoutit
 
-#### v 2.2.3.1  |  13 July 2021  |  commit --  |  Current Version
+#### v 2.2.3.1  |  13 July 2021  |  commit 46b8a49d66d9b76fb9131c73ba6241b215145e53
 * Updated items listed in *Ice Box* section of `README.md` to reflect implemented features.
 * Added the MIT License to the publication and use terms of this website.
+
+#### BRANCH render-layout-through-ssr  |  13 July 2021  |  commit --  |  Current Version
+* Initialized `gatsby-ssr.js` and `gatsby-browser.js` files.
+* Wrote functions in both new files to automatically wrap `<Layout />` around page elements.
+* Removed `<Layout />` wrapper from all render functions and corresponding import statements from relevant files.
+* Confirmed all pages including sub-directories are rendering properly.
 
 [Back to Top](#top)
 
@@ -425,7 +431,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   * The *Other Projects* page may be a single page or it may display links in the same manner as the `/projects` index page and link to projects at `/projects/other/project-name` if that doesn't cause problems for Gatsby.* Add mobile-responsiveness to the design.  This will be a goal for shortly after I reach MVP.
 * Add Google Maps to `/contact` page.  Before doing this I need to decide where to deploy my site and see how they configure hidden data (in this case an API key).  [See here for more information.](https://www.gatsbyjs.com/plugins/gatsby-source-googlemaps-static/)
 * Add Google Analytics to the website.  This should be relatively easy since I already have it set up for my site's previous version.
-* Render the `<Layout>` compoonent using Gatsby Server Rendering APIs. [More info here.](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-ssr/)
 
 [Back to Top](#top)
 

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import Layout from './src/components/Layout';
+
+export function wrapPageElement({element, props}) {
+    return (
+        <Layout {...props}>{element}</Layout>
+    )
+}
+
+export function wrapRootElement({element}) {
+    return <>{element}</>;
+}

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import Layout from './src/components/Layout';
+
+export function wrapPageElement({element, props}) {
+    return (
+        <Layout {...props}>{element}</Layout>
+    )
+}

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -4,7 +4,6 @@ import React from "react";
 
 
 /******* START: IMPORT LOCAL FILES *******/
-import Layout from '../components/Layout';
 import * as styles from '../styles/404.module.css';
 /******* END: IMPORT LOCAL FILES *******/
 
@@ -18,7 +17,6 @@ export default function NotFound() {
     </>;
 
     return (
-        <Layout>
             <div className={styles.notfound_main}>
                 <section>
                     <h1>404</h1>
@@ -28,6 +26,5 @@ export default function NotFound() {
                     {text}
                 </section>
             </div>
-        </Layout>
     );
 }

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -6,7 +6,6 @@ import Img from 'gatsby-image';
 
 
 /******* START: IMPORT LOCAL FILES *******/
-import Layout from '../components/Layout';
 import * as styles from '../styles/about.module.css';
 /******* END: IMPORT LOCAL FILES *******/
 
@@ -53,7 +52,6 @@ export default function About({data}) {
     const skillsMobile = skillsMobileArray.map((skill, idx) => <p key={idx}>{bullet} {skill} {bullet}</p>);
 
     return (
-        <Layout>
             <div className={styles.about_main}>
                 <section className={styles.about_header}>
                     <h1>About Marty</h1>
@@ -75,7 +73,6 @@ export default function About({data}) {
                     <div className={styles.skills_mobile}>{skillsMobile}</div>
                 </section>
             </div>
-        </Layout>
 	);
 }
 

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -4,7 +4,6 @@ import React from "react";
 
 
 /******* START: IMPORT LOCAL FILES *******/
-import Layout from '../components/Layout';
 import * as styles from '../styles/contact.module.css';
 import envelope_icon from '../images/icons/envelope-icon.svg';
 import linkedin_solid_icon from '../images/icons/linkedin-solid-icon.svg';
@@ -16,7 +15,6 @@ export default function Contact() {
 	const formPreviewText = 'Before sending a note realize you risk it being missed amongst the 10-20 spam messages this form generates daily.  Email & LinkedIn are the best ways to contact me.';
 
     return (
-        <Layout>
             <div className={styles.contact_main}>
                 <section className={styles.contact_header}>
                     <h1>Messaging</h1>
@@ -69,10 +67,8 @@ export default function Contact() {
                 {/* <section className={styles.contact_header}>
                     <h1>Over Coffee</h1>
                     <hr />
-
                 </section> */}
                 {/* TODO: in the future I'll embed a Google Map here, see README.md Future Plans/Icebox for more information */}
             </div>
-        </Layout>
 	);
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,7 +4,6 @@ import {Link} from 'gatsby';
 /******* END: IMPORT REACT AND DONGLES *******/
 
 /******* START: IMPORT LOCAL FILES *******/
-import Layout from '../components/Layout';
 import * as styles from '../styles/home.module.css';
 import about_icon from '../images/icons/about-icon.svg';
 import projects_icon from '../images/icons/projects-icon.svg';
@@ -55,7 +54,6 @@ export default function Home() {
 	));
 
 	return (
-		<Layout>
 			<div className={styles.home_main}>
 				<section className={styles.grid_intro}>
 					<h4>Hi, my name is</h4>
@@ -69,6 +67,5 @@ export default function Home() {
 					{linkData}
 				</section>
 			</div>
-		</Layout>
 	);
 }

--- a/src/pages/projects/index.js
+++ b/src/pages/projects/index.js
@@ -6,7 +6,6 @@ import Img from 'gatsby-image';
 
 
 /******* START: IMPORT LOCAL FILES *******/
-import Layout from '../../components/Layout';
 import * as styles from '../../styles/projects.module.css';
 /******* END: IMPORT LOCAL FILES *******/
 
@@ -38,7 +37,6 @@ export default function Projects({data}) {
     ));
 
 	return (
-        <Layout>
             <div className={styles.projects_main}>
                 <section>
                     <h1>Projects</h1>
@@ -52,7 +50,6 @@ export default function Projects({data}) {
                     </Link> */}
                 </section>
             </div>
-        </Layout>
 	);
 }
 

--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -5,7 +5,6 @@ import {Link} from 'gatsby';
 
 
 /******* START: IMPORT LOCAL FILES *******/
-import Layout from '../components/Layout';
 import * as styles from '../styles/resources.module.css';
 import web_dev_icon from '../images/icons/web-dev-icon.svg';
 import html_css_icon from '../images/icons/html-css-icon.svg';
@@ -49,7 +48,6 @@ export default function Resources() {
     ));
 
     return (
-        <Layout>
             <div className={styles.resources_main}>
                 <section>
                     <h1>Resources</h1>
@@ -59,6 +57,5 @@ export default function Resources() {
                     {resourcesLinkData}
                 </section>
             </div>
-        </Layout>
 	);
 }

--- a/src/templates/project-details.js
+++ b/src/templates/project-details.js
@@ -6,52 +6,49 @@ import { GatsbyImage } from "gatsby-plugin-image";
 
 
 /******* START: IMPORT LOCAL FILES *******/
-import Layout from '../components/Layout';
 import * as styles from '../styles/project-details.module.css';
 /******* END: IMPORT LOCAL FILES *******/
 
 
 export default function ProjectDetails({data}) {
-    const {html} = data.markdownRemark;
-    const {title, app, repo} = data.markdownRemark.frontmatter;
-    const fluid = data.markdownRemark.frontmatter.fullImg.childImageSharp.gatsbyImageData;
+	const {html} = data.markdownRemark;
+	const {title, app, repo} = data.markdownRemark.frontmatter;
+	const fluid = data.markdownRemark.frontmatter.fullImg.childImageSharp.gatsbyImageData;
 
-    return (
-        <Layout>
-            <article className={styles.details}>
-                <h1>{title}</h1>
-                <hr />
-                <section className={styles.details_content}>
-                    <div className={styles.project_picture_frame}>
-                        <GatsbyImage alt={title} image={fluid} />
-                    </div>
-                    <div className={styles.details_text} >
-                        <div className={styles.project_details_html} dangerouslySetInnerHTML={{__html: html}} />
-                        <div className={styles.details_linkdiv}>
-                            <a href={app} target="_blank" rel="noreferrer">Link to Live App</a>
-                        </div>
-                        <div className={styles.details_linkdiv}>
-                            <a href={repo} target="_blank" rel="noreferrer">Link to Repo</a>
-                        </div>
-                    </div>
-                </section>
-            </article>
-        </Layout>
-    );
+	return (
+		<article className={styles.details}>
+			<h1>{title}</h1>
+			<hr />
+			<section className={styles.details_content}>
+				<div className={styles.project_picture_frame}>
+					<GatsbyImage alt={title} image={fluid} />
+				</div>
+				<div className={styles.details_text} >
+					<div className={styles.project_details_html} dangerouslySetInnerHTML={{__html: html}} />
+					<div className={styles.details_linkdiv}>
+						<a href={app} target="_blank" rel="noreferrer">Link to Live App</a>
+					</div>
+					<div className={styles.details_linkdiv}>
+						<a href={repo} target="_blank" rel="noreferrer">Link to Repo</a>
+					</div>
+				</div>
+			</section>
+		</article>
+	);
 }
 
 export const query = graphql`query ProjectDetail($slug: String) {
   markdownRemark(frontmatter: {slug: {eq: $slug}}) {
-    html
-    frontmatter {
-      title
-      app
-      repo
-      fullImg {
-        childImageSharp {
-          gatsbyImageData(layout: FULL_WIDTH)
-        }
-      }
-    }
+	html
+	frontmatter {
+	  title
+	  app
+	  repo
+	  fullImg {
+		childImageSharp {
+		  gatsbyImageData(layout: FULL_WIDTH)
+		}
+	  }
+	}
   }
 }`

--- a/src/templates/resource-details.js
+++ b/src/templates/resource-details.js
@@ -6,7 +6,6 @@ import { GatsbyImage } from "gatsby-plugin-image";
 
 
 /******* START: IMPORT LOCAL FILES *******/
-import Layout from '../components/Layout';
 import * as styles from '../styles/resource-details.module.css';
 /******* END: IMPORT LOCAL FILES *******/
 
@@ -42,7 +41,7 @@ export default function ResourceDetails({location, data}) {
                         <GatsbyImage alt={node.frontmatter.title} image={node.frontmatter.squareImg.childImageSharp.gatsbyImageData} />
                     </div>
                     <div className={styles.resource_article_text}>
-                        <div className={styles.resource_details_html} dangerouslySetInnerHTML={{__html: node.html}} />
+                        <div dangerouslySetInnerHTML={{__html: node.html}} />
                         <div className={styles.resource_linkdiv}>
                             <a className={styles.resource_external_hyperlink} href={node.frontmatter.url} target="_blank" rel="noreferrer">Click to View</a>
                         </div>
@@ -53,17 +52,15 @@ export default function ResourceDetails({location, data}) {
     ));
 
     return (
-        <Layout>
-            <div className={styles.resource_subgroup}>
-                <section className={styles.resource_subgroup_header}>
-                    <h1>{pageTitle}</h1>
-                    <hr />
-                </section>
-                <section>
-                    {resourceLinks}
-                </section>
-            </div>
-        </Layout>
+        <div className={styles.resource_subgroup}>
+            <section className={styles.resource_subgroup_header}>
+                <h1>{pageTitle}</h1>
+                <hr />
+            </section>
+            <section>
+                {resourceLinks}
+            </section>
+        </div>
     );
 }
 


### PR DESCRIPTION
I now use gatsby-ssr.js and gatsby-browser.js to render my <Layout /> wrapper component and apply it to rendered pages.  Better use of Gatsby features to create DRY code.

With this commit the feature is complete and fully implemented.